### PR TITLE
レア環境の画面表示を変更

### DIFF
--- a/app/src/main/java/com/example/environment_sensing/RareEnvironmentChecker.kt
+++ b/app/src/main/java/com/example/environment_sensing/RareEnvironmentChecker.kt
@@ -8,20 +8,20 @@ data class RareEnvironment(
 object RareEnvironmentChecker {
 
     private val environments = listOf(
-        RareEnvironment("台風環境") {
+        RareEnvironment("低気圧×高温レア環境") { /*台風を想定*/
             it.pressure <= 990 && it.temperature >= 30
         },
-        RareEnvironment("クラブ環境") {
+        RareEnvironment("暗い×うるさいレア環境") {/*クラブを想定*/
             it.light <= 30 && it.noise >= 80
         },
-        RareEnvironment("砂漠環境") {
+        RareEnvironment("乾燥×高温レア環境") {/*砂漠のような環境を想定*/
             it.humidity <= 30 && it.temperature >= 30
         },
-        RareEnvironment("密室真夏") {
+        RareEnvironment("高温×息苦しさレア環境") {/*真夏の密室を想定*/
             it.temperature >= 30 && it.co2 >= 600
         },
-        RareEnvironment("シーシャバー") {
-            it.tvoc >= 500 && it.co2 >= 600
+        RareEnvironment("薄暗い×有機ガスレア環境") {/*シーシャバーを想定*/
+            it.light <= 30 && it.tvoc >= 500
         }
     )
 


### PR DESCRIPTION
レア環境をゲットした際に出るメッセージが環境名（シーシャバーやクラブなど）になっており、その場所以外でゲットした場合に間違った推定だと思われてしまうのを避けるために変更しました。
具体的には（環境名）ゲット！ではなく、（高気温×高湿度）ゲット！のように状態を表示するようにしました。